### PR TITLE
Add inheritdoc to generated Json serializers

### DIFF
--- a/src/TransparentValueObjects/JsonAugmentWriter.cs
+++ b/src/TransparentValueObjects/JsonAugmentWriter.cs
@@ -113,6 +113,7 @@ public static class JsonAugmentWriter
         bool isReferenceType,
         BaseType baseType)
     {
+        cw.AppendLine("/// <inheritdoc />");
         cw.AppendLine($"public override {targetTypeSimpleName} Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)");
         using var _ = cw.AddBlock();
 
@@ -147,6 +148,7 @@ public static class JsonAugmentWriter
         string targetTypeSimpleName,
         BaseType baseType)
     {
+        cw.AppendLine("/// <inheritdoc />");
         cw.AppendLine($"public override void Write(global::System.Text.Json.Utf8JsonWriter writer, {targetTypeSimpleName} value, global::System.Text.Json.JsonSerializerOptions options)");
         using var _ = cw.AddBlock();
 
@@ -177,6 +179,7 @@ public static class JsonAugmentWriter
         string innerValueTypeGlobalName,
         BaseType baseType)
     {
+        cw.AppendLine("/// <inheritdoc />");
         cw.AppendLine($"public override {targetTypeSimpleName} ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)");
         using var _ = cw.AddBlock();
 
@@ -211,6 +214,7 @@ public static class JsonAugmentWriter
         string targetTypeSimpleName,
         BaseType baseType)
     {
+        cw.AppendLine("/// <inheritdoc />");
         cw.AppendLine($"public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, {targetTypeSimpleName} value, global::System.Text.Json.JsonSerializerOptions options)");
         using var _ = cw.AddBlock();
 

--- a/src/TransparentValueObjects/JsonAugmentWriter.cs
+++ b/src/TransparentValueObjects/JsonAugmentWriter.cs
@@ -113,7 +113,7 @@ public static class JsonAugmentWriter
         bool isReferenceType,
         BaseType baseType)
     {
-        cw.AppendLine("/// <inheritdoc />");
+        cw.AppendLine(Constants.InheritDocumentation);
         cw.AppendLine($"public override {targetTypeSimpleName} Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)");
         using var _ = cw.AddBlock();
 
@@ -148,7 +148,7 @@ public static class JsonAugmentWriter
         string targetTypeSimpleName,
         BaseType baseType)
     {
-        cw.AppendLine("/// <inheritdoc />");
+        cw.AppendLine(Constants.InheritDocumentation);
         cw.AppendLine($"public override void Write(global::System.Text.Json.Utf8JsonWriter writer, {targetTypeSimpleName} value, global::System.Text.Json.JsonSerializerOptions options)");
         using var _ = cw.AddBlock();
 
@@ -179,7 +179,7 @@ public static class JsonAugmentWriter
         string innerValueTypeGlobalName,
         BaseType baseType)
     {
-        cw.AppendLine("/// <inheritdoc />");
+        cw.AppendLine(Constants.InheritDocumentation);
         cw.AppendLine($"public override {targetTypeSimpleName} ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)");
         using var _ = cw.AddBlock();
 
@@ -214,7 +214,7 @@ public static class JsonAugmentWriter
         string targetTypeSimpleName,
         BaseType baseType)
     {
-        cw.AppendLine("/// <inheritdoc />");
+        cw.AppendLine(Constants.InheritDocumentation);
         cw.AppendLine($"public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, {targetTypeSimpleName} value, global::System.Text.Json.JsonSerializerOptions options)");
         using var _ = cw.AddBlock();
 

--- a/src/TransparentValueObjects/PostInitializationOutput/Augments/EfCoreAugment.cs
+++ b/src/TransparentValueObjects/PostInitializationOutput/Augments/EfCoreAugment.cs
@@ -16,8 +16,7 @@ namespace {{Constants.Namespace}}
 {
     /// <summary>
     /// Augment to enable support for EF Core model configuration by generting a
-    /// <see cref="global::Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter{TModel,TProvider}"/>
-    /// and a <see cref="global::Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer{T}"/>.
+    /// ValueConverter and a ValueComparer.
     /// </summary>
     /// <remarks>
     /// This requires <c>Microsoft.EntityFrameworkCore</c>.

--- a/tests/TransparentValueObjects.Tests/PostInitializationOutput/Augments/EfCoreAugmentTests.Test_Source.verified.cs
+++ b/tests/TransparentValueObjects.Tests/PostInitializationOutput/Augments/EfCoreAugmentTests.Test_Source.verified.cs
@@ -4,8 +4,7 @@ namespace TransparentValueObjects
 {
     /// <summary>
     /// Augment to enable support for EF Core model configuration by generting a
-    /// <see cref="global::Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter{TModel,TProvider}"/>
-    /// and a <see cref="global::Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer{T}"/>.
+    /// ValueConverter and a ValueComparer.
     /// </summary>
     /// <remarks>
     /// This requires <c>Microsoft.EntityFrameworkCore</c>.

--- a/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_Int16.verified.cs
+++ b/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_Int16.verified.cs
@@ -5,6 +5,7 @@
 	/// </summary>
 	public class JsonConverter : global::System.Text.Json.Serialization.JsonConverter<TestValueObject>
 	{
+		/// <inheritdoc/>
 		public override TestValueObject Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			if ((options.NumberHandling & global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString) == global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString && reader.TokenType == global::System.Text.Json.JsonTokenType.String)
@@ -17,11 +18,13 @@
 			return From(reader.GetInt16());
 		}
 
+		/// <inheritdoc/>
 		public override void Write(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WriteNumberValue(value.Value);
 		}
 
+		/// <inheritdoc/>
 		public override TestValueObject ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var stringValue = reader.GetString();
@@ -29,6 +32,7 @@
 			return From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WritePropertyName(value.Value.ToString(global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_Int32.verified.cs
+++ b/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_Int32.verified.cs
@@ -5,6 +5,7 @@
 	/// </summary>
 	public class JsonConverter : global::System.Text.Json.Serialization.JsonConverter<TestValueObject>
 	{
+		/// <inheritdoc/>
 		public override TestValueObject Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			if ((options.NumberHandling & global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString) == global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString && reader.TokenType == global::System.Text.Json.JsonTokenType.String)
@@ -17,11 +18,13 @@
 			return From(reader.GetInt32());
 		}
 
+		/// <inheritdoc/>
 		public override void Write(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WriteNumberValue(value.Value);
 		}
 
+		/// <inheritdoc/>
 		public override TestValueObject ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var stringValue = reader.GetString();
@@ -29,6 +32,7 @@
 			return From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WritePropertyName(value.Value.ToString(global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_Int64.verified.cs
+++ b/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_Int64.verified.cs
@@ -5,6 +5,7 @@
 	/// </summary>
 	public class JsonConverter : global::System.Text.Json.Serialization.JsonConverter<TestValueObject>
 	{
+		/// <inheritdoc/>
 		public override TestValueObject Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			if ((options.NumberHandling & global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString) == global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString && reader.TokenType == global::System.Text.Json.JsonTokenType.String)
@@ -17,11 +18,13 @@
 			return From(reader.GetInt64());
 		}
 
+		/// <inheritdoc/>
 		public override void Write(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WriteNumberValue(value.Value);
 		}
 
+		/// <inheritdoc/>
 		public override TestValueObject ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var stringValue = reader.GetString();
@@ -29,6 +32,7 @@
 			return From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WritePropertyName(value.Value.ToString(global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_UInt16.verified.cs
+++ b/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_UInt16.verified.cs
@@ -5,6 +5,7 @@
 	/// </summary>
 	public class JsonConverter : global::System.Text.Json.Serialization.JsonConverter<TestValueObject>
 	{
+		/// <inheritdoc/>
 		public override TestValueObject Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			if ((options.NumberHandling & global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString) == global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString && reader.TokenType == global::System.Text.Json.JsonTokenType.String)
@@ -17,11 +18,13 @@
 			return From(reader.GetUInt16());
 		}
 
+		/// <inheritdoc/>
 		public override void Write(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WriteNumberValue(value.Value);
 		}
 
+		/// <inheritdoc/>
 		public override TestValueObject ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var stringValue = reader.GetString();
@@ -29,6 +32,7 @@
 			return From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WritePropertyName(value.Value.ToString(global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_UInt32.verified.cs
+++ b/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_UInt32.verified.cs
@@ -5,6 +5,7 @@
 	/// </summary>
 	public class JsonConverter : global::System.Text.Json.Serialization.JsonConverter<TestValueObject>
 	{
+		/// <inheritdoc/>
 		public override TestValueObject Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			if ((options.NumberHandling & global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString) == global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString && reader.TokenType == global::System.Text.Json.JsonTokenType.String)
@@ -17,11 +18,13 @@
 			return From(reader.GetUInt32());
 		}
 
+		/// <inheritdoc/>
 		public override void Write(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WriteNumberValue(value.Value);
 		}
 
+		/// <inheritdoc/>
 		public override TestValueObject ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var stringValue = reader.GetString();
@@ -29,6 +32,7 @@
 			return From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WritePropertyName(value.Value.ToString(global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_UInt64.verified.cs
+++ b/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsNumbers.Test_UInt64.verified.cs
@@ -5,6 +5,7 @@
 	/// </summary>
 	public class JsonConverter : global::System.Text.Json.Serialization.JsonConverter<TestValueObject>
 	{
+		/// <inheritdoc/>
 		public override TestValueObject Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			if ((options.NumberHandling & global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString) == global::System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString && reader.TokenType == global::System.Text.Json.JsonTokenType.String)
@@ -17,11 +18,13 @@
 			return From(reader.GetUInt64());
 		}
 
+		/// <inheritdoc/>
 		public override void Write(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WriteNumberValue(value.Value);
 		}
 
+		/// <inheritdoc/>
 		public override TestValueObject ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var stringValue = reader.GetString();
@@ -29,6 +32,7 @@
 			return From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WritePropertyName(value.Value.ToString(global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsReferenceType.Test_JsonAugment.verified.cs
+++ b/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsReferenceType.Test_JsonAugment.verified.cs
@@ -5,23 +5,27 @@
 	/// </summary>
 	public class JsonConverter : global::System.Text.Json.Serialization.JsonConverter<TestValueObject>
 	{
+		/// <inheritdoc/>
 		public override TestValueObject Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var innerValue = reader.GetString();
 			return innerValue is null ? DefaultValue : From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void Write(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WriteStringValue(value.Value);
 		}
 
+		/// <inheritdoc/>
 		public override TestValueObject ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var innerValue = reader.GetString();
 			return innerValue is null ? DefaultValue : From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WritePropertyName(value.Value);

--- a/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsValueType.Test_JsonAugment.verified.cs
+++ b/tests/TransparentValueObjects.Tests/SourceOutput/Augments/JsonAugmentTestsValueType.Test_JsonAugment.verified.cs
@@ -5,23 +5,27 @@
 	/// </summary>
 	public class JsonConverter : global::System.Text.Json.Serialization.JsonConverter<TestValueObject>
 	{
+		/// <inheritdoc/>
 		public override TestValueObject Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var innerValue = reader.GetGuid();
 			return From(innerValue);
 		}
 
+		/// <inheritdoc/>
 		public override void Write(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WriteStringValue(value.Value);
 		}
 
+		/// <inheritdoc/>
 		public override TestValueObject ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			var innerValue = reader.GetString();
 			return From(innerValue is null ? global::System.Guid.Empty : global::System.Guid.Parse(innerValue));
 		}
 
+		/// <inheritdoc/>
 		public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TestValueObject value, global::System.Text.Json.JsonSerializerOptions options)
 		{
 			writer.WritePropertyName(value.Value.ToString());


### PR DESCRIPTION
We're getting build warnings due to the members of this class not having doc strings, this just adds "inheritdoc" to these 4 members (and updates the tests).

Also fixes a bug where we were always emitting doc string references to EF even when EF wasn't installed or used. For now, just deleted the doc references to these classes and instead use the un-annotated names. This also removes 2 warnings for every generated value object